### PR TITLE
Base theme assets version on framework assets version if available.

### DIFF
--- a/ThemeBundle/Resources/config/services.yml
+++ b/ThemeBundle/Resources/config/services.yml
@@ -21,5 +21,7 @@ services:
             - @kernel
             - @assets.packages
             - @assets.empty_version_strategy
+        calls:
+            - [setContainer, [@service_container]]
         tags:
             - { name: kernel.event_subscriber }


### PR DESCRIPTION
`assets._version__default` is a service generated by the framework only when asset configuration is defined in configuration. In this case, with this code update, theme assets will have their URL versionned.