### PR TITLE
Use more suitable assets version strategy for theme assets.

### DIFF
--- a/ThemeBundle/Resources/config/services.yml
+++ b/ThemeBundle/Resources/config/services.yml
@@ -20,6 +20,6 @@ services:
         arguments:
             - @kernel
             - @assets.packages
-            - @assets.empty_version_strategy
+            - "@=container.has('assets._version__default') ? service('assets._version__default') : service('assets.empty_version_strategy')"
         tags:
             - { name: kernel.event_subscriber }


### PR DESCRIPTION
`assets._version__default` is a service generated by the framework only when asset configuration is defined in configuration. In this case, with this code update, theme assets will have their URL versionned.